### PR TITLE
Add note about you having to log in

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Test servers: https://github.com/DragonetMC/DragonProxy/blob/master/TestServers.
 #### Join on Pocket/Win 10 Edition here `hypixel.dragonet.org`, port `19132`(default). 
 
 ## Installation
-[![Build status indicator](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master.svg?style=badge)](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master) [Download from CircleCI](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master)
+[![Build status indicator](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master.svg?style=badge)](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master) [Download from CircleCI](https://circleci.com/gh/DragonetMC/DragonProxy/tree/master) - You must be logged in to download a build.
 
 #### Supported Remote Server Types
 - `Bukkit`/`Spigot`/`Glowstone`/`SpongeVanilla`/`BungeeCord`


### PR DESCRIPTION
Apparently artifacts don't show up when you aren't logged in. Logging in with my Github account finally made the artifacts tab show up.