### PR TITLE
Transform JSON Messages into colored plain text, fix colors in plain text.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
     </repositories>
 
     <dependencies>
+		<dependency>
+			<groupId>org.codehaus.jettison</groupId>
+			<artifactId>jettison</artifactId>
+			<version>1.3.3</version>
+		</dependency>
         <dependency>
             <groupId>org.spacehq</groupId>
             <artifactId>mcprotocollib</artifactId>

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
@@ -72,6 +72,91 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
         while (iter.hasNext()) {
             String key = iter.next();
             try {
+            	if (key.equals("color")) {
+            		String color = jObject.getString(key);
+              		if (color.equals("light_purple")) {
+            			chatMessage = chatMessage + "§d";
+            		}
+              		
+              		if (color.equals("blue")) {
+            			chatMessage = chatMessage + "§9";
+            		}
+              		if (color.equals("aqua")) {
+            			chatMessage = chatMessage + "§b";
+            		}
+            		if (color.equals("gold")) {
+            			chatMessage = chatMessage + "§6";
+            		}
+            		if (color.equals("green")) {
+            			chatMessage = chatMessage + "§a";
+            		}
+              		if (color.equals("white")) {
+            			chatMessage = chatMessage + "§f";
+            		}
+              		if (color.equals("yellow")) {
+            			chatMessage = chatMessage + "§e";
+            		}
+              		if (color.equals("gray")) {
+            			chatMessage = chatMessage + "§7";
+            		}
+              		if (color.equals("red")) {
+            			chatMessage = chatMessage + "§c";
+            		}
+              		if (color.equals("black")) {
+            			chatMessage = chatMessage + "§0";
+            		}
+              		
+              		if (color.equals("dark_green")) {
+            			chatMessage = chatMessage + "§2";
+            		}
+              		if (color.equals("dark_gray")) {
+            			chatMessage = chatMessage + "§8";
+            		}
+              		if (color.equals("dark_red")) {
+            			chatMessage = chatMessage + "§4";
+            		}
+              		if (color.equals("dark_blue")) {
+            			chatMessage = chatMessage + "§1";
+            		}
+              		if (color.equals("dark_aqua")) {
+            			chatMessage = chatMessage + "§3";
+            		}
+              		if (color.equals("dark_purple")) {
+            			chatMessage = chatMessage + "§5";
+            		}
+            	}
+            	
+            	if (key.equals("bold")) {
+            		String bold = jObject.getString(key);
+            		if (bold.equals("true")) {
+            			chatMessage = chatMessage + "§l";
+            		}
+            	}
+            	if (key.equals("italic")) {
+            		String bold = jObject.getString(key);
+            		if (bold.equals("true")) {
+            			chatMessage = chatMessage + "§o";
+            		}
+            	}
+            	if (key.equals("underlined")) {
+            		String bold = jObject.getString(key);
+            		if (bold.equals("true")) {
+            			chatMessage = chatMessage + "§n";
+            		}
+            	}
+            	if (key.equals("underlined")) {
+            		String bold = jObject.getString(key);
+            		if (bold.equals("true")) {
+            			chatMessage = chatMessage + "§m";
+            		}
+            	}
+            	if (key.equals("obfuscated")) {
+            		String bold = jObject.getString(key);
+            		if (bold.equals("true")) {
+            			chatMessage = chatMessage + "§k";
+            		}
+            	}
+            	
                 if (key.equals("text")) {
                     /*
                      * We only need the text message from the JSON.

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
@@ -37,6 +37,11 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
         ret.message = packet.getMessage().getFullText();
         switch (packet.getType()) {
             case CHAT:
+            	/*
+            	 * Do not ask me why, but json strings has colors.
+            	 * Changing this allows colors in plain texts! yay!
+            	 */
+            	ret.message = packet.getMessage().toJsonString();
                 ret.type = ChatPacket.TextType.CHAT;
                 /*
                  * It is a JSON message?

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
@@ -24,8 +24,8 @@ import org.dragonet.proxy.network.translator.PCPacketTranslator;
 import org.spacehq.mc.protocol.packet.ingame.server.ServerChatPacket;
 
 public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPacket> {
-	String chatMessage = "";
-	
+    String chatMessage = "";
+    
     @Override
     public PEPacket[] translate(UpstreamSession session, ServerChatPacket packet) {
         ChatPacket ret = new ChatPacket();
@@ -41,22 +41,22 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
                 /*
                  * It is a JSON message?
                  */
-				try {
-					JSONObject jObject = new JSONObject(ret.message);
-					/*
-					 * Let's iterate!
-					 */
-					handleKeyObject(jObject);
-					ret.message = chatMessage;
-				} catch (JSONException e) {
-					/*
-					 * If any exceptions happens, then:
-					 * * The JSON message is buggy or
-					 * * It isn't a JSON message
-					 * 
-					 * So, if any exceptions happens, we send the original message
-					 */
-				} 
+                try {
+                    JSONObject jObject = new JSONObject(ret.message);
+                    /*
+                     * Let's iterate!
+                     */
+                    handleKeyObject(jObject);
+                    ret.message = chatMessage;
+                } catch (JSONException e) {
+                    /*
+                     * If any exceptions happens, then:
+                     * * The JSON message is buggy or
+                     * * It isn't a JSON message
+                     * 
+                     * So, if any exceptions happens, we send the original message
+                     */
+                } 
                 break;
             case NOTIFICATION:
             case SYSTEM:
@@ -68,52 +68,52 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
     }
     
     public void handleKeyObject(JSONObject jObject) throws JSONException {
-    	Iterator<String> iter = jObject.keys();
-		while (iter.hasNext()) {
-		    String key = iter.next();
-		    try {
-		    	if (key.equals("text")) {
-		    		/*
-		    		 * We only need the text message from the JSON.
-		    		 */
-		    		String jsonMessage = jObject.getString(key);
-		    		chatMessage = chatMessage + jsonMessage;
-		    		continue;
-		    	}
-		    	if (jObject.get(key) instanceof JSONArray) {
-		    		handleKeyArray(jObject.getJSONArray(key));
-		    	}
-		    	if (jObject.get(key) instanceof JSONObject) {
-		    		handleKeyObject(jObject.getJSONObject(key));
-		    	}
-		    } catch (JSONException e) {
-		    }
-		}
+        Iterator<String> iter = jObject.keys();
+        while (iter.hasNext()) {
+            String key = iter.next();
+            try {
+                if (key.equals("text")) {
+                    /*
+                     * We only need the text message from the JSON.
+                     */
+                    String jsonMessage = jObject.getString(key);
+                    chatMessage = chatMessage + jsonMessage;
+                    continue;
+                }
+                if (jObject.get(key) instanceof JSONArray) {
+                    handleKeyArray(jObject.getJSONArray(key));
+                }
+                if (jObject.get(key) instanceof JSONObject) {
+                    handleKeyObject(jObject.getJSONObject(key));
+                }
+            } catch (JSONException e) {
+            }
+        }
     }
     
     
     public void handleKeyArray(JSONArray jObject) throws JSONException {
-    	JSONObject jsonObject = jObject.toJSONObject(jObject);
-    	Iterator<String> iter = jsonObject.keys();
-		while (iter.hasNext()) {
-		    String key = iter.next();
-		    try {
-	    		/*
-	    		 * We only need the text message from the JSON.
-	    		 */
-		    	if (key.equals("text")) {
-		    		String jsonMessage = jsonObject.getString(key);
-		    		chatMessage = chatMessage + jsonMessage;
-		    		continue;
-		    	}
-		    	if (jsonObject.get(key) instanceof JSONArray) {
-		    		handleKeyArray(jsonObject.getJSONArray(key));
-		    	}
-		    	if (jsonObject.get(key) instanceof JSONObject) {
-		    		handleKeyObject(jsonObject.getJSONObject(key));
-		    	}
-		    } catch (JSONException e) {
-		    }
-		}
+        JSONObject jsonObject = jObject.toJSONObject(jObject);
+        Iterator<String> iter = jsonObject.keys();
+        while (iter.hasNext()) {
+            String key = iter.next();
+            try {
+                /*
+                 * We only need the text message from the JSON.
+                 */
+                if (key.equals("text")) {
+                    String jsonMessage = jsonObject.getString(key);
+                    chatMessage = chatMessage + jsonMessage;
+                    continue;
+                }
+                if (jsonObject.get(key) instanceof JSONArray) {
+                    handleKeyArray(jsonObject.getJSONArray(key));
+                }
+                if (jsonObject.get(key) instanceof JSONObject) {
+                    handleKeyObject(jsonObject.getJSONObject(key));
+                }
+            } catch (JSONException e) {
+            }
+        }
     }
 }

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
@@ -12,6 +12,11 @@
  */
 package org.dragonet.proxy.network.translator.pc;
 
+import java.util.Iterator;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 import org.dragonet.net.packet.minecraft.ChatPacket;
 import org.dragonet.net.packet.minecraft.PEPacket;
 import org.dragonet.proxy.network.UpstreamSession;
@@ -19,15 +24,39 @@ import org.dragonet.proxy.network.translator.PCPacketTranslator;
 import org.spacehq.mc.protocol.packet.ingame.server.ServerChatPacket;
 
 public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPacket> {
-
+	String chatMessage = "";
+	
     @Override
     public PEPacket[] translate(UpstreamSession session, ServerChatPacket packet) {
         ChatPacket ret = new ChatPacket();
+        /*
+         * Reset the chat message so we can parse the JSON again (if needed)
+         */
+        chatMessage = "";
         ret.source = "";
         ret.message = packet.getMessage().getFullText();
         switch (packet.getType()) {
             case CHAT:
                 ret.type = ChatPacket.TextType.CHAT;
+                /*
+                 * It is a JSON message?
+                 */
+				try {
+					JSONObject jObject = new JSONObject(ret.message);
+					/*
+					 * Let's iterate!
+					 */
+					handleKeyObject(jObject);
+					ret.message = chatMessage;
+				} catch (JSONException e) {
+					/*
+					 * If any exceptions happens, then:
+					 * * The JSON message is buggy or
+					 * * It isn't a JSON message
+					 * 
+					 * So, if any exceptions happens, we send the original message
+					 */
+				} 
                 break;
             case NOTIFICATION:
             case SYSTEM:
@@ -37,5 +66,54 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
         }
         return new PEPacket[]{ret};
     }
-
+    
+    public void handleKeyObject(JSONObject jObject) throws JSONException {
+    	Iterator<String> iter = jObject.keys();
+		while (iter.hasNext()) {
+		    String key = iter.next();
+		    try {
+		    	if (key.equals("text")) {
+		    		/*
+		    		 * We only need the text message from the JSON.
+		    		 */
+		    		String jsonMessage = jObject.getString(key);
+		    		chatMessage = chatMessage + jsonMessage;
+		    		continue;
+		    	}
+		    	if (jObject.get(key) instanceof JSONArray) {
+		    		handleKeyArray(jObject.getJSONArray(key));
+		    	}
+		    	if (jObject.get(key) instanceof JSONObject) {
+		    		handleKeyObject(jObject.getJSONObject(key));
+		    	}
+		    } catch (JSONException e) {
+		    }
+		}
+    }
+    
+    
+    public void handleKeyArray(JSONArray jObject) throws JSONException {
+    	JSONObject jsonObject = jObject.toJSONObject(jObject);
+    	Iterator<String> iter = jsonObject.keys();
+		while (iter.hasNext()) {
+		    String key = iter.next();
+		    try {
+	    		/*
+	    		 * We only need the text message from the JSON.
+	    		 */
+		    	if (key.equals("text")) {
+		    		String jsonMessage = jsonObject.getString(key);
+		    		chatMessage = chatMessage + jsonMessage;
+		    		continue;
+		    	}
+		    	if (jsonObject.get(key) instanceof JSONArray) {
+		    		handleKeyArray(jsonObject.getJSONArray(key));
+		    	}
+		    	if (jsonObject.get(key) instanceof JSONObject) {
+		    		handleKeyObject(jsonObject.getJSONObject(key));
+		    	}
+		    } catch (JSONException e) {
+		    }
+		}
+    }
 }

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCChatPacketTranslator.java
@@ -25,7 +25,7 @@ import org.spacehq.mc.protocol.packet.ingame.server.ServerChatPacket;
 
 public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPacket> {
     String chatMessage = "";
-    
+
     @Override
     public PEPacket[] translate(UpstreamSession session, ServerChatPacket packet) {
         ChatPacket ret = new ChatPacket();
@@ -35,133 +35,132 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
         chatMessage = "";
         ret.source = "";
         ret.message = packet.getMessage().getFullText();
+        /*
+         * It is a JSON message?
+         */
+        try {
+            /*
+             * Do not ask me why, but json strings has colors.
+             * Changing this allows colors in plain texts! yay!
+             */
+            JSONObject jObject = new JSONObject(packet.getMessage().toJsonString());
+            /*
+             * Let's iterate!
+             */
+            handleKeyObject(jObject);
+            ret.message = chatMessage;
+        } catch (JSONException e) {
+            /*
+             * If any exceptions happens, then:
+             * * The JSON message is buggy or
+             * * It isn't a JSON message
+             * 
+             * So, if any exceptions happens, we send the original message
+             */
+        } 
         switch (packet.getType()) {
-            case CHAT:
-            	/*
-            	 * Do not ask me why, but json strings has colors.
-            	 * Changing this allows colors in plain texts! yay!
-            	 */
-            	ret.message = packet.getMessage().toJsonString();
-                ret.type = ChatPacket.TextType.CHAT;
-                /*
-                 * It is a JSON message?
-                 */
-                try {
-                    JSONObject jObject = new JSONObject(ret.message);
-                    /*
-                     * Let's iterate!
-                     */
-                    handleKeyObject(jObject);
-                    ret.message = chatMessage;
-                } catch (JSONException e) {
-                    /*
-                     * If any exceptions happens, then:
-                     * * The JSON message is buggy or
-                     * * It isn't a JSON message
-                     * 
-                     * So, if any exceptions happens, we send the original message
-                     */
-                } 
-                break;
-            case NOTIFICATION:
-            case SYSTEM:
-            default:
-                ret.type = ChatPacket.TextType.CHAT;
-                break;
+        case CHAT:
+            ret.type = ChatPacket.TextType.CHAT;
+            break;
+        case NOTIFICATION:
+        case SYSTEM:
+        default:
+            ret.type = ChatPacket.TextType.CHAT;
+            break;
         }
         return new PEPacket[]{ret};
     }
-    
+
     public void handleKeyObject(JSONObject jObject) throws JSONException {
         Iterator<String> iter = jObject.keys();
         while (iter.hasNext()) {
             String key = iter.next();
             try {
-            	if (key.equals("color")) {
-            		String color = jObject.getString(key);
-              		if (color.equals("light_purple")) {
-            			chatMessage = chatMessage + "§d";
-            		}
-              		
-              		if (color.equals("blue")) {
-            			chatMessage = chatMessage + "§9";
-            		}
-              		if (color.equals("aqua")) {
-            			chatMessage = chatMessage + "§b";
-            		}
-            		if (color.equals("gold")) {
-            			chatMessage = chatMessage + "§6";
-            		}
-            		if (color.equals("green")) {
-            			chatMessage = chatMessage + "§a";
-            		}
-              		if (color.equals("white")) {
-            			chatMessage = chatMessage + "§f";
-            		}
-              		if (color.equals("yellow")) {
-            			chatMessage = chatMessage + "§e";
-            		}
-              		if (color.equals("gray")) {
-            			chatMessage = chatMessage + "§7";
-            		}
-              		if (color.equals("red")) {
-            			chatMessage = chatMessage + "§c";
-            		}
-              		if (color.equals("black")) {
-            			chatMessage = chatMessage + "§0";
-            		}
-              		
-              		if (color.equals("dark_green")) {
-            			chatMessage = chatMessage + "§2";
-            		}
-              		if (color.equals("dark_gray")) {
-            			chatMessage = chatMessage + "§8";
-            		}
-              		if (color.equals("dark_red")) {
-            			chatMessage = chatMessage + "§4";
-            		}
-              		if (color.equals("dark_blue")) {
-            			chatMessage = chatMessage + "§1";
-            		}
-              		if (color.equals("dark_aqua")) {
-            			chatMessage = chatMessage + "§3";
-            		}
-              		if (color.equals("dark_purple")) {
-            			chatMessage = chatMessage + "§5";
-            		}
-            	}
-            	
-            	if (key.equals("bold")) {
-            		String bold = jObject.getString(key);
-            		if (bold.equals("true")) {
-            			chatMessage = chatMessage + "§l";
-            		}
-            	}
-            	if (key.equals("italic")) {
-            		String bold = jObject.getString(key);
-            		if (bold.equals("true")) {
-            			chatMessage = chatMessage + "§o";
-            		}
-            	}
-            	if (key.equals("underlined")) {
-            		String bold = jObject.getString(key);
-            		if (bold.equals("true")) {
-            			chatMessage = chatMessage + "§n";
-            		}
-            	}
-            	if (key.equals("underlined")) {
-            		String bold = jObject.getString(key);
-            		if (bold.equals("true")) {
-            			chatMessage = chatMessage + "§m";
-            		}
-            	}
-            	if (key.equals("obfuscated")) {
-            		String bold = jObject.getString(key);
-            		if (bold.equals("true")) {
-            			chatMessage = chatMessage + "§k";
-            		}
-            	}
-            	
+                if (key.equals("color")) {
+                    String color = jObject.getString(key);
+                    if (color.equals("light_purple")) {
+                        chatMessage = chatMessage + "§d";
+                    }
+
+                    if (color.equals("blue")) {
+                        chatMessage = chatMessage + "§9";
+                    }
+                    if (color.equals("aqua")) {
+                        chatMessage = chatMessage + "§b";
+                    }
+                    if (color.equals("gold")) {
+                        chatMessage = chatMessage + "§6";
+                    }
+                    if (color.equals("green")) {
+                        chatMessage = chatMessage + "§a";
+                    }
+                    if (color.equals("white")) {
+                        chatMessage = chatMessage + "§f";
+                    }
+                    if (color.equals("yellow")) {
+                        chatMessage = chatMessage + "§e";
+                    }
+                    if (color.equals("gray")) {
+                        chatMessage = chatMessage + "§7";
+                    }
+                    if (color.equals("red")) {
+                        chatMessage = chatMessage + "§c";
+                    }
+                    if (color.equals("black")) {
+                        chatMessage = chatMessage + "§0";
+                    }
+
+                    if (color.equals("dark_green")) {
+                        chatMessage = chatMessage + "§2";
+                    }
+                    if (color.equals("dark_gray")) {
+                        chatMessage = chatMessage + "§8";
+                    }
+                    if (color.equals("dark_red")) {
+                        chatMessage = chatMessage + "§4";
+                    }
+                    if (color.equals("dark_blue")) {
+                        chatMessage = chatMessage + "§1";
+                    }
+                    if (color.equals("dark_aqua")) {
+                        chatMessage = chatMessage + "§3";
+                    }
+                    if (color.equals("dark_purple")) {
+                        chatMessage = chatMessage + "§5";
+                    }
+                }
+
+                if (key.equals("bold")) {
+                    String bold = jObject.getString(key);
+                    if (bold.equals("true")) {
+                        chatMessage = chatMessage + "§l";
+                    }
+                }
+                if (key.equals("italic")) {
+                    String bold = jObject.getString(key);
+                    if (bold.equals("true")) {
+                        chatMessage = chatMessage + "§o";
+                    }
+                }
+                if (key.equals("underlined")) {
+                    String bold = jObject.getString(key);
+                    if (bold.equals("true")) {
+                        chatMessage = chatMessage + "§n";
+                    }
+                }
+                if (key.equals("underlined")) {
+                    String bold = jObject.getString(key);
+                    if (bold.equals("true")) {
+                        chatMessage = chatMessage + "§m";
+                    }
+                }
+                if (key.equals("obfuscated")) {
+                    String bold = jObject.getString(key);
+                    if (bold.equals("true")) {
+                        chatMessage = chatMessage + "§k";
+                    }
+                }
+
                 if (key.equals("text")) {
                     /*
                      * We only need the text message from the JSON.
@@ -180,8 +179,8 @@ public class PCChatPacketTranslator implements PCPacketTranslator<ServerChatPack
             }
         }
     }
-    
-    
+
+
     public void handleKeyArray(JSONArray jObject) throws JSONException {
         JSONObject jsonObject = jObject.toJSONObject(jObject);
         Iterator<String> iter = jsonObject.keys();


### PR DESCRIPTION
Adds Jettison (org.codehaus.jettison) as a dependency.

This commit iterates thru a JSON message (if it is one) and gets all the "text" keys from the JSON, after all text keys are get, the chat packet message (that, without this commit, would send a entire JSON message package unaltered) is changed to a plain text string.

Here is a Server with JSON messages: mc.sparklypower.net (Just wait someone to talk on chat)

As a bonus, plain text colors are fixed too! Yay! (Not tested, but should work, and yes, the screenshots are outdated, use your imagination to see the colors fixed)

**Before:**
![https://cloud.githubusercontent.com/assets/9496359/12075867/928bd9a8-b176-11e5-8f4c-6dc5c6834e2a.png](https://cloud.githubusercontent.com/assets/9496359/12075867/928bd9a8-b176-11e5-8f4c-6dc5c6834e2a.png)

**After:**
(old, when I added support for JSON messages)
![http://i.imgur.com/L8yqQRg.png](http://i.imgur.com/L8yqQRg.png)

(old, when I added color to JSON messages)
![https://cloud.githubusercontent.com/assets/9496359/12371936/734e4344-bc2c-11e5-9633-3660f6330976.png](https://cloud.githubusercontent.com/assets/9496359/12371936/734e4344-bc2c-11e5-9633-3660f6330976.png)

(now, plain text color support & JSON transforming!)
![https://camo.githubusercontent.com/5b5e68c183c3af68be38fd98b3cc33a82961f407/687474703a2f2f692e696d6775722e636f6d2f65386954536134682e6a7067](https://camo.githubusercontent.com/5b5e68c183c3af68be38fd98b3cc33a82961f407/687474703a2f2f692e696d6775722e636f6d2f65386954536134682e6a7067)
**ISSUES**:
Color is a bit buggy.