### PR TITLE
Move the MOTD configuration to the config file.

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -36,6 +36,9 @@ log_console=true
 # If you using it on a multi-player server, you may want to have 2 threads per 50 players. 
 thread_pool_size=32
 
+# The MOTD (Message of the Day) that will be shown on the MCPE Server List
+motd=&aPC Server [%ip%:%port%] by DragonProxy
+
 # ===============================
 #|      Recommanded Servers      |
 # ===============================

--- a/src/main/java/org/dragonet/proxy/DragonProxy.java
+++ b/src/main/java/org/dragonet/proxy/DragonProxy.java
@@ -120,7 +120,14 @@ public class DragonProxy {
         network = new RaknetInterface(this,
                 config.getConfig().getProperty("udp_bind_ip"), //IP
                 Integer.parseInt(config.getConfig().getProperty("udp_bind_port"))); //Port
-        network.setBroadcastName(lang.get(Lang.BROADCAST_TITLE, remoteServerAddress.getHostString(), remoteServerAddress.getPort()));
+        
+        // MOTD
+        String motd = config.getConfig().getProperty("motd");
+        motd = motd.replace("&", "§");
+        motd = motd.replace("%ip%", remoteServerAddress.getHostString());
+        motd = motd.replace("%port%", remoteServerAddress.getPort() + "");
+        
+        network.setBroadcastName(motd);
         ticker.start();
         logger.info(lang.get(Lang.INIT_DONE));
     }


### PR DESCRIPTION
You can use '&' to colorize the MOTD.

The style of the MOTD is set as the same as before, but I added a "&a" to show the color functions.

You can use "%ip%" and "%port%" to show the PC server IP and Port.