### PR TITLE
Fix NPE when downstream connection has not been established

### DIFF
--- a/src/main/java/org/dragonet/proxy/network/UpstreamSession.java
+++ b/src/main/java/org/dragonet/proxy/network/UpstreamSession.java
@@ -144,7 +144,9 @@ public class UpstreamSession {
      */
     public void onDisconnect(String reason) {
         proxy.getLogger().info(proxy.getLang().get(Lang.CLIENT_DISCONNECTED, username, remoteAddress, reason));
-        downstream.disconnect();
+        if (downstream != null) {
+            downstream.disconnect();
+        }
         proxy.getSessionRegister().removeSession(this);
         packetProcessorScheule.cancel(true);
     }


### PR DESCRIPTION
This occurs when the server auth mode is cls but the user has not authed. Probably other scenarios.