### PR TITLE
Update StartGamePacket.java

### DIFF
--- a/src/main/java/org/dragonet/net/packet/minecraft/StartGamePacket.java
+++ b/src/main/java/org/dragonet/net/packet/minecraft/StartGamePacket.java
@@ -52,13 +52,10 @@ public class StartGamePacket extends PEPacket {
             writer.writeFloat(this.x);
             writer.writeFloat(this.y + 1.62f);
             writer.writeFloat(this.z);
-            writer.writeByte((byte) 0);
-            
-            //Unknown stuff
-            writer.writeByte((byte) 0x01);
-            writer.writeByte((byte) 0x01);
+            writer.writeByte((byte) 0x01); //userPerm
+            writer.writeByte((byte) 0x01); //globalPerm
             writer.writeByte((byte) 0x00);
-            writer.writeString("");
+            writer.writeString(""); //Unknown string
             this.setData(bos.toByteArray());
         } catch (IOException e) {
         }


### PR DESCRIPTION
You have made an mistake here
two true bools are new
but you randomly sent another false byte before them, which was right before!
Pre 0.14.2
BlaPosition
FALSE
0.14.2:
oldBlaPosition
newTrue
newTrue
oldFalse
But you sent:
oldFalse
newTrue
newTrue
someRandom False
Maybe because of looking at git diffs?

![screenshot](https://cloud.githubusercontent.com/assets/16020100/15103401/4ed1fe4c-15ab-11e6-801a-d33189e9b91a.png)
I too don't know why these two new bytes have been put between the last and the position and the new string  to the last, but hey it's mojang