### PR TITLE
Update player attributes when health is updated, fixes #123

### DIFF
--- a/src/main/java/org/dragonet/proxy/network/PacketTranslatorRegister.java
+++ b/src/main/java/org/dragonet/proxy/network/PacketTranslatorRegister.java
@@ -12,7 +12,7 @@
  */
 package org.dragonet.proxy.network;
 
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerPlayerListEntryPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.server.*;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.*;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.player.ServerPlayerPositionRotationPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.spawn.ServerSpawnObjectPacket;
@@ -28,10 +28,6 @@ import java.util.Map;
 import org.dragonet.proxy.network.translator.IPEPacketTranslator;
 import org.dragonet.proxy.network.translator.pc.*;
 import org.dragonet.proxy.network.translator.pe.*;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerChatPacket;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerDisconnectPacket; 
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerJoinGamePacket;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerRespawnPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.player.ServerPlayerHealthPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.player.ServerPlayerSetExperiencePacket;
 import com.github.steveice10.mc.protocol.packet.ingame.server.entity.spawn.ServerSpawnMobPacket;
@@ -54,6 +50,7 @@ public final class PacketTranslatorRegister {
         PC_TO_PE_TRANSLATOR.put(ServerDisconnectPacket.class, new PCDisconnectPacketTranslator()); 
         // Settings && Weather
         PC_TO_PE_TRANSLATOR.put(ServerNotifyClientPacket.class, new PCNotifyClientPacketTranslator());
+        PC_TO_PE_TRANSLATOR.put(ServerDifficultyPacket.class, new PCSetDifficultyTranslator());
 
         // Chat
         PC_TO_PE_TRANSLATOR.put(ServerChatPacket.class, new PCChatPacketTranslator());

--- a/src/main/java/org/dragonet/proxy/network/translator/pc/PCSetDifficultyTranslator.java
+++ b/src/main/java/org/dragonet/proxy/network/translator/pc/PCSetDifficultyTranslator.java
@@ -1,0 +1,16 @@
+package org.dragonet.proxy.network.translator.pc;
+
+import com.github.steveice10.mc.protocol.packet.ingame.server.ServerDifficultyPacket;
+import org.dragonet.proxy.network.UpstreamSession;
+import org.dragonet.proxy.network.translator.IPCPacketTranslator;
+import org.dragonet.proxy.protocol.PEPacket;
+import org.dragonet.proxy.protocol.packets.SetDifficultyPacket;
+
+public class PCSetDifficultyTranslator implements IPCPacketTranslator<ServerDifficultyPacket> {
+
+    @Override
+    public PEPacket[] translate(UpstreamSession session, ServerDifficultyPacket packet) {
+        return new PEPacket[]{new SetDifficultyPacket(packet.getDifficulty())};
+    }
+
+}

--- a/src/main/java/org/dragonet/proxy/protocol/Protocol.java
+++ b/src/main/java/org/dragonet/proxy/protocol/Protocol.java
@@ -72,6 +72,7 @@ public final class Protocol {
         packets.put(PLAYER_HOTBAR_PACKET, PlayerHotbarPacket.class);
         packets.put(SET_ENTITY_LINK_PACKET, SetEntityLinkPacket.class);
         packets.put(PLAYER_INPUT_PACKET, PlayerInputPacket.class);
+        packets.put(SET_DIFFICULTY_PACKET, SetDifficultyPacket.class);
 
         packets.put(MODAL_FORM_REQUEST_PACKET, ModalFormRequestPacket.class);
         packets.put(MODAL_FORM_RESPONSE_PACKET, ModalFormResponsePacket.class);

--- a/src/main/java/org/dragonet/proxy/protocol/packets/SetDifficultyPacket.java
+++ b/src/main/java/org/dragonet/proxy/protocol/packets/SetDifficultyPacket.java
@@ -1,0 +1,32 @@
+package org.dragonet.proxy.protocol.packets;
+
+import com.github.steveice10.mc.protocol.data.game.setting.Difficulty;
+import org.dragonet.proxy.protocol.PEPacket;
+import org.dragonet.proxy.protocol.ProtocolInfo;
+
+public class SetDifficultyPacket extends PEPacket {
+
+    public Difficulty difficulty;
+
+    public SetDifficultyPacket() {
+    }
+
+    public SetDifficultyPacket(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    @Override
+    public int pid() {
+        return ProtocolInfo.SET_DIFFICULTY_PACKET;
+    }
+
+    @Override
+    public void encodePayload() {
+        putUnsignedVarInt(this.difficulty.ordinal());
+    }
+
+    @Override
+    public void decodePayload() {
+        this.difficulty = Difficulty.values()[(int) getUnsignedVarInt()];
+    }
+}


### PR DESCRIPTION
The player's attributes are updated whenever the health is updated by the server. This means that the client will no longer take arbitrary damage. In addition, the player's food level will also be updated to the correct value too, instead of just remaining at a full level.
I also added a server difficulty translator. This will make sure that the client will no longer self-heal itself when connected to pc servers that are not on peaceful mode.