### PR TITLE
Use status code 4 for PlayStatus packet

### DIFF
--- a/src/main/java/org/dragonet/proxy/network/UpstreamSession.java
+++ b/src/main/java/org/dragonet/proxy/network/UpstreamSession.java
@@ -311,19 +311,20 @@ public class UpstreamSession {
             disconnect(proxy.getLang().get(Lang.MESSAGE_UNSUPPORTED_CLIENT));
             return;
         }
-        status.status = PlayStatusPacket.LOGIN_SUCCESS;
-        sendPacket(status, true);
-
+        
         // Get the profile and read out the username!
         profile = packet.decoded;
 
         // Verify the integrity of the LoginPacket
         if (proxy.getConfig().authenticate_players && !packet.decoded.isLoginVerified()) {
-            status.status = PlayStatusPacket.LOGIN_FAILED_CLIENT;
+            status.status = PlayStatusPacket.LOGIN_FAILED_INVALID_TENANT;
             sendPacket(status, true);
             disconnect(proxy.getLang().get(Lang.LOGIN_VERIFY_FAILED));
             return;
         }
+        
+        status.status = PlayStatusPacket.LOGIN_SUCCESS;
+        sendPacket(status, true);
 
         this.username = profile.username;
 


### PR DESCRIPTION
If the login was not verified, send status code 4 (LOGIN_FAILED_INVALID_TENANT)
Also make sure that the login success status packet is sent after the login verification check
  