### PR TITLE
add fishing, updated food support, enabled hunger

### DIFF
--- a/commons/src/main/java/org/dragonet/common/data/PocketPotionEffect.java
+++ b/commons/src/main/java/org/dragonet/common/data/PocketPotionEffect.java
@@ -36,7 +36,7 @@ public class PocketPotionEffect {
     public static final int INVISIBILITY = 14;
     // public static final int BLINDNESS = 15;
     // public static final int NIGHT_VISION = 16;
-    // public static final int HUNGER = 17;
+    public static final int HUNGER = 17;
     public static final int WEAKNESS = 18;
     public static final int POISON = 19;
     public static final int WITHER = 20;
@@ -62,6 +62,7 @@ public class PocketPotionEffect {
         EFFECTS.put(FIRE_RESISTANCE, new PocketPotionEffect(FIRE_RESISTANCE));
         EFFECTS.put(WATER_BREATHING, new PocketPotionEffect(WATER_BREATHING));
         EFFECTS.put(INVISIBILITY, new PocketPotionEffect(INVISIBILITY));
+        EFFECTS.put(HUNGER, new PocketPotionEffect(HUNGER));
         EFFECTS.put(WEAKNESS, new PocketPotionEffect(WEAKNESS));
         EFFECTS.put(POISON, new PocketPotionEffect(POISON));
         EFFECTS.put(WITHER, new PocketPotionEffect(WITHER));

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/pc/PCUpdateHealthPacketTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/pc/PCUpdateHealthPacketTranslator.java
@@ -33,8 +33,9 @@ public class PCUpdateHealthPacketTranslator implements IPCPacketTranslator<Serve
         CachedEntity peSelfPlayer = session.getEntityCache().getClientEntity();
 
         peSelfPlayer.attributes.put(PEEntityAttribute.HEALTH, PEEntityAttribute.findAttribute(PEEntityAttribute.HEALTH).setValue(newHealth));
+        if(peSelfPlayer.foodPacketCount==0){
         peSelfPlayer.attributes.put(PEEntityAttribute.FOOD, PEEntityAttribute.findAttribute(PEEntityAttribute.FOOD).setValue(packet.getFood()));
-
+        }
         UpdateAttributesPacket pk = new UpdateAttributesPacket();
         pk.rtid = peSelfPlayer.proxyEid;
         pk.entries = peSelfPlayer.attributes.values();

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/pe/PEEntityEventPacketTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/pe/PEEntityEventPacketTranslator.java
@@ -5,7 +5,11 @@ import org.dragonet.proxy.network.UpstreamSession;
 import org.dragonet.proxy.network.cache.CachedEntity;
 import org.dragonet.proxy.network.translator.IPEPacketTranslator;
 
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
+import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
+import com.github.steveice10.mc.protocol.data.game.world.block.BlockFace;
+import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerActionPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerUseItemPacket;
 import com.github.steveice10.packetlib.packet.Packet;
 
@@ -25,7 +29,8 @@ public class PEEntityEventPacketTranslator implements IPEPacketTranslator<Entity
             player.lastFoodPacketTime = t;
             if(session.getEntityCache().getClientEntity().foodPacketCount==7){
                 session.getEntityCache().getClientEntity().foodPacketCount=0;
-                return new Packet[]{new ClientPlayerUseItemPacket(Hand.MAIN_HAND)};
+                player.lastFoodPacketTime = t;
+                return null;
             }
         }
         return null;

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/pe/PEInventoryTransactionPacketTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/pe/PEInventoryTransactionPacketTranslator.java
@@ -1,8 +1,10 @@
 package org.dragonet.proxy.network.translator.pe;
 
+import org.dragonet.common.data.entity.EntityType;
 import org.dragonet.common.data.inventory.ContainerId;
 import org.dragonet.common.data.inventory.Slot;
 import org.dragonet.common.maths.BlockPosition;
+import org.dragonet.protocol.packets.AddEntityPacket;
 import org.dragonet.protocol.packets.InventoryTransactionPacket;
 import org.dragonet.protocol.type.transaction.InventoryTransactionAction;
 import org.dragonet.protocol.type.transaction.data.ReleaseItemData;
@@ -19,6 +21,7 @@ import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
 import com.github.steveice10.mc.protocol.data.game.entity.player.InteractAction;
+import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
 import com.github.steveice10.mc.protocol.data.game.window.ClickItemParam;
 import com.github.steveice10.mc.protocol.data.game.window.WindowAction;
 import com.github.steveice10.mc.protocol.data.game.world.block.BlockFace;
@@ -26,6 +29,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlaye
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerInteractEntityPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPlaceBlockPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerSwingArmPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerUseItemPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientWindowActionPacket;
 import com.github.steveice10.packetlib.packet.Packet;
 
@@ -136,8 +140,12 @@ public class PEInventoryTransactionPacketTranslator implements IPEPacketTranslat
         case InventoryTransactionPacket.TYPE_USE_ITEM: //2
             System.out.println("TYPE_USE_ITEM");
             UseItemData useItemData = (UseItemData) packet.transactionData;
+            if(useItemData.itemInHand.id==346){
+                AddEntityPacket pk = new AddEntityPacket();
+                return new Packet[]{new ClientPlayerUseItemPacket(Hand.MAIN_HAND)};
+            }
             if (useItemData.blockPos.equals(new BlockPosition(0, 0, 0))) {
-                return null;
+                return new Packet[]{new ClientPlayerUseItemPacket(Hand.MAIN_HAND)};
             }
             switch (useItemData.actionType) {
             case InventoryTransactionPacket.USE_ITEM_ACTION_BREAK_BLOCK: //2
@@ -182,6 +190,10 @@ public class PEInventoryTransactionPacketTranslator implements IPEPacketTranslat
             return new Packet[]{interractPacket};
         case InventoryTransactionPacket.TYPE_RELEASE_ITEM: //4
             System.out.println("TYPE_RELEASE_ITEM");
+            if(((ReleaseItemData)packet.transactionData).actionType==0){
+                return new Packet[]{new ClientPlayerUseItemPacket(Hand.MAIN_HAND), new ClientPlayerActionPacket(PlayerAction.RELEASE_USE_ITEM, new Position(0, 0, 0), BlockFace.DOWN)};
+            }
+
             ReleaseItemData releaseItemData = (ReleaseItemData) packet.transactionData;
             //                ClientPlayerActionPacket act = new ClientPlayerActionPacket(
             //                    com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction.DROP_ITEM,


### PR DESCRIPTION
I've done some changes on the eating support, because there were some issues with the previous one (eating was processed by the server when it was finished on bedrock client). Now, the process is sync between client and server, but there may be some issues with some untested actions that use the same packets.
I've also added a basic support for fishing (no sound and no particles for the moment, it's a separate task), just the fishing hook can be seen.
I've also enabled the hunger effet, I don't know why it was disabled, I haven't had any issue with it.