### PR TITLE
Fixed BungeeCord maven repository

### DIFF
--- a/plugin/bungee/pom.xml
+++ b/plugin/bungee/pom.xml
@@ -15,8 +15,8 @@
 
     <repositories>
         <repository>
-            <id>spigotMC-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>BungeeCord-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The maven repository of SpigotMC doesn't contain BungeeCord. This one does.