### PR TITLE
Support for Minecraft 1.4.0 Update

### DIFF
--- a/protocol/src/main/java/org/dragonet/protocol/ProtocolInfo.java
+++ b/protocol/src/main/java/org/dragonet/protocol/ProtocolInfo.java
@@ -10,16 +10,16 @@ public class ProtocolInfo {
     /**
      * Actual Minecraft: PE protocol version
      */
-    public static final int CURRENT_PROTOCOL = 223;
+    public static final int CURRENT_PROTOCOL = 261;
     /**
      * Current Minecraft PE version reported by the server. This is usually the
      * earliest currently supported version.
      */
-    public static final String MINECRAFT_VERSION = "v1.2.13";
+    public static final String MINECRAFT_VERSION = "v1.4.0";
     /**
      * Version number sent to clients in ping responses.
      */
-    public static final String MINECRAFT_VERSION_NETWORK = "1.2.13";
+    public static final String MINECRAFT_VERSION_NETWORK = "1.4.0";
 
     public static final byte LOGIN_PACKET = (byte) 0x01;
     public static final byte PLAY_STATUS_PACKET = (byte) 0x02;


### PR DESCRIPTION
The 1.4 Update Aquatic just came out today, and I updated the protocol number and version numbers accordingly.