### PR TITLE
Fix bug with ports

### DIFF
--- a/bootstrap/src/main/java/org/dragonet/proxy/Bootstrap.java
+++ b/bootstrap/src/main/java/org/dragonet/proxy/Bootstrap.java
@@ -50,7 +50,7 @@ public class Bootstrap {
         }
 
         int bedrockPort = options.has(bedrockPortOption) ? Integer.parseInt(options.valueOf(bedrockPortOption)) : -1;
-        int javaPort = options.has(javaPortOption) ? Integer.parseInt(options.valueOf(bedrockPortOption)) : -1;
+        int javaPort = options.has(javaPortOption) ? Integer.parseInt(options.valueOf(javaPortOption)) : -1;
 
         DragonProxy proxy = new DragonProxy(bedrockPort, javaPort);
 


### PR DESCRIPTION
When command line options are used, the javaPort was incorrectly set to bedrockPortOption.