### PR TITLE
Fix for skins not showing in hybrid servers

### DIFF
--- a/proxy/src/main/java/org/dragonet/proxy/configuration/DragonConfiguration.java
+++ b/proxy/src/main/java/org/dragonet/proxy/configuration/DragonConfiguration.java
@@ -59,6 +59,9 @@ public class DragonConfiguration {
     @JsonProperty("ping-passthrough")
     private boolean pingPassthrough;
 
+    @JsonProperty("force-player-skins")
+    private boolean forcePlayerSkins;
+
     @JsonProperty("player-settings")
     private PlayerConfig playerConfig;
 

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/java/player/PCSpawnPlayerTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/java/player/PCSpawnPlayerTranslator.java
@@ -25,6 +25,7 @@ import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.protocol.bedrock.data.ImageData;
 import com.nukkitx.protocol.bedrock.packet.PlayerListPacket;
 import lombok.extern.log4j.Log4j2;
+import org.dragonet.proxy.configuration.DragonConfiguration;
 import org.dragonet.proxy.data.PlayerListInfo;
 import org.dragonet.proxy.network.session.ProxySession;
 import org.dragonet.proxy.network.session.cache.object.CachedPlayer;
@@ -59,9 +60,11 @@ public class PCSpawnPlayerTranslator extends PacketTranslator<ServerSpawnPlayerP
         cachedPlayer.setRotation(Vector3f.from(packet.getYaw(), packet.getPitch(), 0));
         cachedPlayer.spawn(session);
 
-        if(session.getProxy().getConfiguration().getRemoteAuthType() == RemoteAuthType.OFFLINE) {
+        DragonConfiguration config = session.getProxy().getConfiguration();
+        if(config.getRemoteAuthType() == RemoteAuthType.OFFLINE && !config.isForcePlayerSkins()) {
             return;
         }
+
         if(session.getProxy().getConfiguration().getPlayerConfig().isFetchSkin()) {
             session.getProxy().getGeneralThreadPool().execute(() -> {
                 GameProfile profile = playerListEntry.getProfile();

--- a/proxy/src/main/resources/config.yml
+++ b/proxy/src/main/resources/config.yml
@@ -36,6 +36,9 @@ xbox-auth: false
 # Whether or not to use the motd and player count of the primary remote server
 ping-passthrough: true
 
+# Forces Player Skins on Hybrid servers
+force-player-skins: false
+
 # Player gameplay related settings
 player-settings:
   # Whether or not to translate commands sent from the remote server and display


### PR DESCRIPTION
Fixes skins in offline server using a hybrid environment now showing. Adds the config option force-player-skins. If this is true (when auth-type=offline) then skins will still be processed