### PR TITLE
Fix MOTD/Player count on ping passthrough

### DIFF
--- a/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
@@ -405,7 +405,7 @@ public class ProxySession implements PlayerSession {
         startGamePacket.setWorldTemplateOptionLocked(false);
 
         startGamePacket.setLevelId(UUID.randomUUID().toString());
-        startGamePacket.setWorldName(proxy.getConfiguration().getMotd2());
+        startGamePacket.setWorldName("DragonProxy " + proxy.getVersion());
         startGamePacket.setPremiumWorldTemplateId("00000000-0000-0000-0000-000000000000");
         startGamePacket.setCurrentTick(0);
         startGamePacket.setEnchantmentSeed(0);

--- a/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
@@ -405,7 +405,7 @@ public class ProxySession implements PlayerSession {
         startGamePacket.setWorldTemplateOptionLocked(false);
 
         startGamePacket.setLevelId(UUID.randomUUID().toString());
-        startGamePacket.setWorldName("DragonProxy " + proxy.getVersion());
+        startGamePacket.setWorldName(proxy.getConfiguration().getMotd2());
         startGamePacket.setPremiumWorldTemplateId("00000000-0000-0000-0000-000000000000");
         startGamePacket.setCurrentTick(0);
         startGamePacket.setEnchantmentSeed(0);


### PR DESCRIPTION
This fixes server showing as offline when ping pass through is enabled.

Noticable changes:
+ Added subMOTD to replace world name as on LAN games
+ Removed MOTD from Ping pass through as java MOTD look completely broken on bedrock
+ Removed version from being added to the end of the MOTD
+ Ping passthrough now only manages player count