### PR TITLE
Fix signs, titles and update mcauthlib

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>mcauthlib</artifactId>
-            <version>1.2-SNAPSHOT</version>
+            <version>1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/bedrock/world/PEBlockEntityDataTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/bedrock/world/PEBlockEntityDataTranslator.java
@@ -18,7 +18,10 @@
  */
 package org.dragonet.proxy.network.translator.bedrock.world;
 
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientSetBeaconEffectPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientUpdateSignPacket;
+import com.google.common.collect.ObjectArrays;
 import com.nukkitx.nbt.tag.CompoundTag;
 import com.nukkitx.protocol.bedrock.packet.BlockEntityDataPacket;
 import lombok.extern.log4j.Log4j2;
@@ -37,11 +40,17 @@ public class PEBlockEntityDataTranslator extends PacketTranslator<BlockEntityDat
         }
         CompoundTag tag = (CompoundTag) packet.getData();
 
-        log.warn(tag);
-
         switch(tag.getString("id")) {
             case "Sign":
-                //ClientUpdateSignPacket clientUpdateSignPacket = new ClientUpdateSignPacket(new Position());
+                String[] signText = ((CompoundTag) packet.getData()).getString("Text").split("\\r?\\n");
+                String[] signDefault = new String[] { "\n", "\n", "\n", "\n" };
+                for(int i = 0; i < signText.length; i++) {
+                    signDefault[i] = signText[i];
+                }
+
+                Position pos = new Position(packet.getBlockPosition().getX(), packet.getBlockPosition().getY(), packet.getBlockPosition().getZ());
+                ClientUpdateSignPacket clientUpdateSignPacket = new ClientUpdateSignPacket(pos, signDefault);
+                session.sendRemotePacket(clientUpdateSignPacket);
                 break;
             case "Beacon":
                 session.sendRemotePacket(new ClientSetBeaconEffectPacket(tag.getInt("primary"), tag.getInt("secondary")));

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/bedrock/world/PEBlockEntityDataTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/bedrock/world/PEBlockEntityDataTranslator.java
@@ -21,7 +21,6 @@ package org.dragonet.proxy.network.translator.bedrock.world;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.packet.ingame.client.window.ClientSetBeaconEffectPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.client.world.ClientUpdateSignPacket;
-import com.google.common.collect.ObjectArrays;
 import com.nukkitx.nbt.tag.CompoundTag;
 import com.nukkitx.protocol.bedrock.packet.BlockEntityDataPacket;
 import lombok.extern.log4j.Log4j2;

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/java/PCTitleTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/java/PCTitleTranslator.java
@@ -18,6 +18,7 @@
  */
 package org.dragonet.proxy.network.translator.java;
 
+import com.github.steveice10.mc.protocol.data.message.ChatColor;
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerTitlePacket;
 import com.nukkitx.protocol.bedrock.packet.SetTitlePacket;
 import lombok.extern.log4j.Log4j2;
@@ -45,6 +46,16 @@ public class PCTitleTranslator extends PacketTranslator<ServerTitlePacket> {
                 bedrockPacket.setText(MessageTranslator.translate(packet.getTitle()));
                 break;
             case TITLE:
+                //Otherwise title is black when no colour specified
+                if(packet.getTitle().getStyle().getColor() == ChatColor.NONE) {
+                    packet.getTitle().getStyle().setColor(ChatColor.WHITE);
+                }
+
+                //Change black to none other wise title background is also black
+                if(packet.getTitle().getStyle().getColor() == ChatColor.BLACK) {
+                    packet.getTitle().getStyle().setColor(ChatColor.NONE);
+                }
+
                 bedrockPacket.setType(SetTitlePacket.Type.SET_TITLE);
                 bedrockPacket.setText(MessageTranslator.translate(packet.getTitle()));
                 break;

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/misc/BlockEntityTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/misc/BlockEntityTranslator.java
@@ -18,6 +18,11 @@
  */
 package org.dragonet.proxy.network.translator.misc;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.steveice10.mc.protocol.data.message.ChatColor;
+import com.github.steveice10.mc.protocol.data.message.Message;
+import com.github.steveice10.mc.protocol.data.message.MessageStyle;
+import com.google.gson.JsonObject;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -25,9 +30,12 @@ import com.nukkitx.protocol.bedrock.packet.BlockEntityDataPacket;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.extern.log4j.Log4j2;
+import net.minidev.json.JSONObject;
+import org.dragonet.proxy.DragonProxy;
 import org.dragonet.proxy.network.session.ProxySession;
 import org.dragonet.proxy.util.TextFormat;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -110,6 +118,30 @@ public class BlockEntityTranslator {
                 root.intTag("Secondary", (int) javaTag.get("Secondary").getValue());
                 root.intTag("Levels", (int) javaTag.get("Levels").getValue());
                 root.stringTag("Lock", "");
+                break;
+            case "Sign":
+                String signText = "";
+                for(int i = 0; i < 4; i++) {
+
+                    log.warn(bedrockId);
+                    log.warn(javaTag);
+
+                    int currentLine = i+1;
+
+                    //Signs have different color names than chat color ugh
+                    String color = javaTag.get("Color").getValue().toString()
+                    .replaceAll("\\bblue\\b", "dark_blue")
+                    .replaceAll("\\bgray\\b", "dark_gray")
+                    .replaceAll("\\blight_blue\\b", "blue")
+                    .replaceAll("\\blight_gray\\b", "gray");
+
+                    Message message = Message.fromString(javaTag.get("Text" + currentLine).getValue().toString());
+                    message.getExtra().forEach(messageExtra -> {
+                        messageExtra.setStyle(new MessageStyle().setColor(ChatColor.byName(color)));
+                    });
+                    signText += MessageTranslator.translate(message) + "\n";
+                }
+                root.stringTag("Text", signText);
                 break;
         }
 

--- a/proxy/src/main/java/org/dragonet/proxy/network/translator/misc/BlockEntityTranslator.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/translator/misc/BlockEntityTranslator.java
@@ -18,11 +18,9 @@
  */
 package org.dragonet.proxy.network.translator.misc;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.steveice10.mc.protocol.data.message.ChatColor;
 import com.github.steveice10.mc.protocol.data.message.Message;
 import com.github.steveice10.mc.protocol.data.message.MessageStyle;
-import com.google.gson.JsonObject;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.CompoundTagBuilder;
 import com.nukkitx.nbt.tag.CompoundTag;
@@ -30,15 +28,9 @@ import com.nukkitx.protocol.bedrock.packet.BlockEntityDataPacket;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.extern.log4j.Log4j2;
-import net.minidev.json.JSONObject;
-import org.dragonet.proxy.DragonProxy;
 import org.dragonet.proxy.network.session.ProxySession;
 import org.dragonet.proxy.util.TextFormat;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Log4j2
@@ -122,10 +114,6 @@ public class BlockEntityTranslator {
             case "Sign":
                 String signText = "";
                 for(int i = 0; i < 4; i++) {
-
-                    log.warn(bedrockId);
-                    log.warn(javaTag);
-
                     int currentLine = i+1;
 
                     //Signs have different color names than chat color ugh


### PR DESCRIPTION
Fixed Signs (mostly)
  - Colour works, text is now visible instead of signs being blank.
  - They're sometimes still invisible but not sure why yet
  - Signs can be placed by bedrock players but only first letter is valid. Still working on it
Updates MCAuthLib
  - Updates AuthLib to 1.3
Fixed title colour
 - Titles now defaultly appear white instead of black
 - Black colour now changed to "None" to avoid unreadable text