### PR TITLE
Attempted Fix at random bedrock crashes

### DIFF
--- a/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
+++ b/proxy/src/main/java/org/dragonet/proxy/network/session/ProxySession.java
@@ -436,7 +436,7 @@ public class ProxySession implements PlayerSession {
         sendPacket(playStatusPacket);
 
         if(!disconnect) {
-            cachedEntity = entityCache.newPlayer(1, entityId, new GameProfile(getAuthData().getIdentity(), getAuthData().getDisplayName()));
+            cachedEntity = entityCache.newPlayer(Integer.MIN_VALUE, entityId, new GameProfile(getAuthData().getIdentity(), getAuthData().getDisplayName()));
         }
     }
 


### PR DESCRIPTION
When a sendFakeGameStart was sent the unique entity ID of the player was hard coded as 1. This player is obviously the bedrock player so has to stay in the cache. 

However, when joining the java server, entities are sent to dragonproxy with the entity ID. For example in CapeCraft's hub a floating item has an entityID of 1. Now when you walk to far away from this entity a ServerEntityDestroyPacket is sent for entityID 1 (The Item) but as DP has seemed to merge the player and item into one entry, the player is removed from the cache causing bedrock to crash.

As Entity ID's should never be negative, I have set the player entity ID to Integer.MIN_VALUE. Theoretically this could fix many other crashes players have due to entities. 